### PR TITLE
Don't automatically use WAIT_HOSTS/WAIT_PATHS

### DIFF
--- a/.github/workflows/support/docker-compose.override.yml
+++ b/.github/workflows/support/docker-compose.override.yml
@@ -10,9 +10,7 @@ services:
       postgres
         -c "listen_addresses=*"
         -c "synchronous_commit=off"
-        -c "checkpoint_completion_target=0.8"
         -c "wal_writer_delay=10000ms"
-        -c "random_page_cost=1.1"
         -c "max_locks_per_transaction=96"
         -c "shared_buffers=1GB"
         -c "effective_cache_size=3GB"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 # syntax=docker/dockerfile:1.4
-# Using syntax 1.4 or higher is required for here-documents; see https://github.com/moby/buildkit/blob/dockerfile/1.4.0/frontend/dockerfile/docs/syntax.md#here-documents
 
 
 ################################################################################

--- a/README.md
+++ b/README.md
@@ -28,10 +28,7 @@ _remco_ or _catalina.sh_:
 * Use `WAIT_HOSTS`, `WAIT_PATHS`, and [others as
   documented](https://github.com/ufoscout/docker-compose-wait#additional-configuration-options) to
   wait for other hosts or file paths before proceeding. If none are provided, `wait` will exit with
-  code 0 immediately and the container will proceed. If `WAIT_HOSTS` is not set and
-  `DHIS2_DATABASE_HOST` is provided, `WAIT_HOSTS` will be set as
-  `WAIT_HOSTS=${DHIS2_DATABASE_HOST}:${DHIS2_DATABASE_PORT:-5432}`. Similarly, if Redis is enabled,
-  the host and port will be added to `WAIT_HOSTS`.
+  code 0 immediately and the container will proceed.
 
 * If `FORCE_HEALTHCHECK_WAIT` is set to `1`, netcat will listen on port 8080 and respond to a single
   http request with "200 OK" and an empty body. This is to allow an orchestrator to mark as a new
@@ -66,36 +63,35 @@ _/usr/local/share/dhis2-init.d/_ to skip.
 **NOTE:** If `dhis2_init.sh` is not run, it is the responsibility of the operator to ensure the
 database is initiated and ready prior to being used by DHIS2.
 
+The following environment variables are set in `dhis2_init.sh` but can be changed as necessary:
+
+  * `DHIS2_DATABASE_NAME` (default: "dhis2")
+  * `DHIS2_DATABASE_USERNAME` (default: "dhis")
+  * `DHIS2_DATABASE_PASSWORD` (optional, but strongly recommended), or contents in
+    `DHIS2_DATABASE_PASSWORD_FILE`
+  * `PGHOST`, or `DHIS2_DATABASE_HOST` (default: "localhost")
+  * `PGPORT` (default: "5432")
+  * `PGDATABASE` (default: "postgres")
+  * `PGUSER` (default: "postgres", must be a PostgreSQL superuser)
+  * `PGPASSWORD` (optional, but strongly recommended, may be required for `PGUSER` in most
+    PostgreSQL installations), or contents in `PGPASSWORD_FILE`
+
 ### dhis2-init.d scripts
 
 * `10_dhis2-database.sh`: Create and initialize a PostgreSQL database with PostGIS. If `WAIT_HOSTS`
-  is empty or null, it will be set to `PGHOST`/`DHIS2_DATABASE_HOST`:`PGPORT`/"5432" and the script
-  will proceed once the database service is ready. The script requires the following environment
-  variables set:
+  or `WAIT_PATHS` are provided, it will wait for hosts or file paths before proceeding. In
+  addition to various `PG*` values being set for connecting to the database, the script
+  requires the following environment variables set:
 
-    * `DHIS2_DATABASE_NAME` (default: "dhis2")
-    * `DHIS2_DATABASE_USERNAME` (default: "dhis")
-    * `DHIS2_DATABASE_PASSWORD` (optional, but strongly recommended), or contents in
-      `DHIS2_DATABASE_PASSWORD_FILE`
-    * `PGHOST`, or `DHIS2_DATABASE_HOST` (default: "localhost")
-    * `PGPORT` (default: "5432")
-    * `PGUSER` (default: "postgres", must be a PostgreSQL superuser)
-    * `PGPASSWORD` (optional, but strongly recommended, may be required for `PGUSER` in most
-      PostgreSQL installations), or contents in `PGPASSWORD_FILE`
+    * `DHIS2_DATABASE_NAME`
+    * `DHIS2_DATABASE_USERNAME`
+    * `DHIS2_DATABASE_PASSWORD`
 
 * `15_pgstatstatements.sh`: Add the
   [pg_stat_statements](https://www.postgresql.org/docs/current/pgstatstatements.html) extension to
-  the `PGDATABASE`. This module is included in the PostGIS container image. If `WAIT_HOSTS` is empty
-  or null, it will be set to `PGHOST`/`DHIS2_DATABASE_HOST`:`PGPORT`/"5432" and the script will
-  proceed once the database service is ready. The script requires the following environment
-  variables set:
-
-    * `PGDATABASE` (default: "postgres")
-    * `PGHOST`, or `DHIS2_DATABASE_HOST` (default: "localhost")
-    * `PGPORT` (default: "5432")
-    * `PGUSER` (default: "postgres", must be a PostgreSQL superuser)
-    * `PGPASSWORD` (optional, but strongly recommended, may be required for `PGUSER` in most
-      PostgreSQL installations), or contents in `PGPASSWORD_FILE`
+  the `PGDATABASE`. This module is included in the PostGIS container image. If `WAIT_HOSTS` or
+  `WAIT_PATHS` are provided, it will wait for hosts or file paths before proceeding. The various
+  `PG*` values can be set as needed to connect to the database.
 
 * `20_dhis2-initwar.sh`: If the last line in _/dhis2-init.progress/20_dhis2-initwar_history.csv_
   does not contain a line stating that the current DHIS2 version and build revision started
@@ -460,10 +456,10 @@ EOF
 
 docker compose up --detach
 
-# Later, upgrade to 2.37.1:
+# Later, upgrade to 2.38.0:
 
 cat >> .env <<'EOF'
-DHIS2_TAG=2.37.1
+DHIS2_TAG=2.38.0
 EOF
 
 docker compose stop dhis2

--- a/dhis2-init.d/10_dhis2-database.sh
+++ b/dhis2-init.d/10_dhis2-database.sh
@@ -22,7 +22,6 @@ ITEMS=(
   rm
   tail
   tee
-  /usr/local/bin/wait
 )
 for ITEM in "${ITEMS[@]}"; do
   if ! command -V "$ITEM" &>/dev/null ; then
@@ -35,83 +34,38 @@ done
 ################################################################################
 
 
-STATUS_FILE="/dhis2-init.progress/${SELF%.sh}_status.txt"
+if [[ -d /dhis2-init.progress/ ]]; then
 
-# Ensure status file parent directory exists
-if [[ ! -d "$( dirname "$STATUS_FILE" )" ]]; then
-  mkdir -p "$( dirname "$STATUS_FILE" )"
-fi
+  STATUS_FILE="/dhis2-init.progress/${SELF%.sh}_status.txt"
 
-if [[ "${DHIS2_INIT_FORCE:-0}" == "1" ]]; then
-  echo "[DEBUG] $SELF: DHIS2_INIT_FORCE=1; delete \"$STATUS_FILE\"..." >&2
-  rm -v -f "$STATUS_FILE"
-fi
+  # Ensure status file parent directory exists
+  if [[ ! -d "$( dirname "$STATUS_FILE" )" ]]; then
+    mkdir -p "$( dirname "$STATUS_FILE" )"
+  fi
 
-# Exit if this script has successfully completed previously and DHIS2_INIT_FORCE is not equal to "1"
-if [[ "${DHIS2_INIT_FORCE:-0}" != "1" ]] && { tail -1 "$STATUS_FILE" | grep -q 'COMPLETED$' ; } 2>/dev/null ; then
-  echo "[INFO] $SELF: script was previously completed successfully, skipping..."
-  exit 0
-fi
+  if [[ "${DHIS2_INIT_FORCE:-0}" == "1" ]]; then
+    echo "[DEBUG] $SELF: DHIS2_INIT_FORCE=1; delete \"$STATUS_FILE\"..." >&2
+    rm -v -f "$STATUS_FILE"
+  fi
 
+  # Exit if this script has successfully completed previously and DHIS2_INIT_FORCE is not equal to "1"
+  if [[ "${DHIS2_INIT_FORCE:-0}" != "1" ]] && { tail -1 "$STATUS_FILE" | grep -q 'COMPLETED$' ; } 2>/dev/null ; then
+    echo "[INFO] $SELF: script was previously completed successfully, skipping..."
+    exit 0
+  fi
 
-################################################################################
-
-
-# If DHIS2_DATABASE_PASSWORD is empty or null, set it to the contents of DHIS2_DATABASE_PASSWORD_FILE
-if [[ -z "${DHIS2_DATABASE_PASSWORD:-}" ]] && [[ -r "${DHIS2_DATABASE_PASSWORD_FILE:-}" ]]; then
-  export DHIS2_DATABASE_PASSWORD="$(<"${DHIS2_DATABASE_PASSWORD_FILE}")"
-fi
-
-# If PGPASSWORD is empty or null, set it to the contents of PGPASSWORD_FILE
-if [[ -z "${PGPASSWORD:-}" ]] && [[ -r "${PGPASSWORD_FILE:-}" ]]; then
-  export PGPASSWORD="$(<"${PGPASSWORD_FILE}")"
-fi
-
-# If PGHOST is empty or null, set it to DHIS2_DATABASE_HOST if provided
-if [[ -z "${PGHOST:-}" ]] && [[ -n "${DHIS2_DATABASE_HOST:-}" ]]; then
-  export PGHOST="${DHIS2_DATABASE_HOST:-}"
-fi
-
-# Set default values if not provided in the environment
-if [[ -z "${DHIS2_DATABASE_USERNAME:-}" ]]; then
-  export DHIS2_DATABASE_USERNAME='dhis'
-fi
-if [[ -z "${DHIS2_DATABASE_NAME:-}" ]]; then
-  export DHIS2_DATABASE_NAME='dhis2'
-fi
-if [[ -z "${PGHOST:-}" ]]; then
-  export PGHOST='localhost'
-fi
-if [[ -z "${PGPORT:-}" ]]; then
-  export PGPORT='5432'
-fi
-if [[ -z "${PGUSER:-}" ]]; then
-  export PGUSER='postgres'
-fi
-
-# If WAIT_HOSTS is empty or null, set to PGHOST:PGPORT
-if [[ -z "${WAIT_HOSTS:-}" ]]; then
-  export WAIT_HOSTS="${PGHOST}:${PGPORT}"
 fi
 
 
 ################################################################################
 
 
-# Wait for hosts specified in the environment variable WAIT_HOSTS (noop if not set).
-# If it times out before the targets are available, it will exit with a non-0 code,
-# and this script will quit because of the bash option "set -e" above.
-# https://github.com/ufoscout/docker-compose-wait
-/usr/local/bin/wait 2> >( sed -r -e 's/^\[(DEBUG|INFO)\s+(wait)\]/[\1] \2:/g' >&2 )
-
-
-################################################################################
-
-
-# The following section requires the following environment variables set:
+# The section below requires the following environment variables set:
 # - DHIS2_DATABASE_NAME
 # - DHIS2_DATABASE_USERNAME
 # - DHIS2_DATABASE_PASSWORD (optional, but strongly recommended)
+
+# The following are optional but may be required to proceed:
 # - PGHOST
 # - PGPORT
 # - PGUSER
@@ -234,5 +188,9 @@ fi
 ################################################################################
 
 
-# Record script progess
-echo "$SELF: COMPLETED" | tee "$STATUS_FILE"
+if [[ -d /dhis2-init.progress/ ]]; then
+  # Record script progess
+  echo "$SELF: COMPLETED" | tee "$STATUS_FILE"
+else
+  echo "$SELF: COMPLETED"
+fi

--- a/dhis2-init.d/15_pgstatstatements.sh
+++ b/dhis2-init.d/15_pgstatstatements.sh
@@ -22,7 +22,6 @@ ITEMS=(
   rm
   tail
   tee
-  /usr/local/bin/wait
 )
 for ITEM in "${ITEMS[@]}"; do
   if ! command -V "$ITEM" &>/dev/null ; then
@@ -35,75 +34,36 @@ done
 ################################################################################
 
 
-STATUS_FILE="/dhis2-init.progress/${SELF%.sh}_status.txt"
+if [[ -d /dhis2-init.progress/ ]]; then
 
-# Ensure status file parent directory exists
-if [[ ! -d "$( dirname "$STATUS_FILE" )" ]]; then
-  mkdir -p "$( dirname "$STATUS_FILE" )"
-fi
+  STATUS_FILE="/dhis2-init.progress/${SELF%.sh}_status.txt"
 
-if [[ "${DHIS2_INIT_FORCE:-0}" == "1" ]]; then
-  echo "[DEBUG] $SELF: DHIS2_INIT_FORCE=1; delete \"$STATUS_FILE\"..." >&2
-  rm -v -f "$STATUS_FILE"
-fi
+  # Ensure status file parent directory exists
+  if [[ ! -d "$( dirname "$STATUS_FILE" )" ]]; then
+    mkdir -p "$( dirname "$STATUS_FILE" )"
+  fi
 
-# Exit if this script has successfully completed previously and DHIS2_INIT_FORCE is not equal to "1"
-if [[ "${DHIS2_INIT_FORCE:-0}" != "1" ]] && { tail -1 "$STATUS_FILE" | grep -q 'COMPLETED$' ; } 2>/dev/null ; then
-  echo "[INFO] $SELF: script was previously completed successfully, skipping..."
-  exit 0
-fi
+  if [[ "${DHIS2_INIT_FORCE:-0}" == "1" ]]; then
+    echo "[DEBUG] $SELF: DHIS2_INIT_FORCE=1; delete \"$STATUS_FILE\"..." >&2
+    rm -v -f "$STATUS_FILE"
+  fi
 
+  # Exit if this script has successfully completed previously and DHIS2_INIT_FORCE is not equal to "1"
+  if [[ "${DHIS2_INIT_FORCE:-0}" != "1" ]] && { tail -1 "$STATUS_FILE" | grep -q 'COMPLETED$' ; } 2>/dev/null ; then
+    echo "[INFO] $SELF: script was previously completed successfully, skipping..."
+    exit 0
+  fi
 
-################################################################################
-
-
-# If PGPASSWORD is empty or null, set it to the contents of PGPASSWORD_FILE
-if [[ -z "${PGPASSWORD:-}" ]] && [[ -r "${PGPASSWORD_FILE:-}" ]]; then
-  export PGPASSWORD="$(<"${PGPASSWORD_FILE}")"
-fi
-
-# If PGHOST is empty or null, set it to DHIS2_DATABASE_HOST if provided
-if [[ -z "${PGHOST:-}" ]] && [[ -n "${DHIS2_DATABASE_HOST:-}" ]]; then
-  export PGHOST="${DHIS2_DATABASE_HOST:-}"
-fi
-
-# Set default values if not provided in the environment
-if [[ -z "${PGDATABASE:-}" ]]; then
-  export PGDATABASE='postgres'
-fi
-if [[ -z "${PGHOST:-}" ]]; then
-  export PGHOST='localhost'
-fi
-if [[ -z "${PGPORT:-}" ]]; then
-  export PGPORT='5432'
-fi
-if [[ -z "${PGUSER:-}" ]]; then
-  export PGUSER='postgres'
-fi
-
-# If WAIT_HOSTS is empty or null, set to PGHOST:PGPORT
-if [[ -z "${WAIT_HOSTS:-}" ]]; then
-  export WAIT_HOSTS="${PGHOST}:${PGPORT}"
 fi
 
 
 ################################################################################
 
 
-# Wait for hosts specified in the environment variable WAIT_HOSTS (noop if not set).
-# If it times out before the targets are available, it will exit with a non-0 code,
-# and this script will quit because of the bash option "set -e" above.
-# https://github.com/ufoscout/docker-compose-wait
-/usr/local/bin/wait 2> >( sed -r -e 's/^\[(DEBUG|INFO)\s+(wait)\]/[\1] \2:/g' >&2 )
-
-
-################################################################################
-
-
-# The following section requires the following environment variables set:
-# - PGDATABASE
+# The section below may require the following environment variables to be set:
 # - PGHOST
 # - PGPORT
+# - PGDATABASE
 # - PGUSER
 # - PGPASSWORD
 
@@ -122,5 +82,9 @@ fi
 ################################################################################
 
 
-# Record script progess
-echo "$SELF: COMPLETED" | tee "$STATUS_FILE"
+if [[ -d /dhis2-init.progress/ ]]; then
+  # Record script progess
+  echo "$SELF: COMPLETED" | tee "$STATUS_FILE"
+else
+  echo "$SELF: COMPLETED"
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,17 +89,13 @@ services:
         target: /pass_pg_postgres
         read_only: true
     environment:
-      DHIS2_DATABASE_HOST: database
+      DHIS2_DATABASE_HOST: database  # Matches the name of the Compose service running PostgreSQL
       DHIS2_DATABASE_PASSWORD_FILE: /pass_pg_dhis/pass_pg_dhis.txt
       DHIS2_INIT_SKIP: 20_dhis2-initwar.sh  # String like "item1.sh,item2.sh"; NOTE: Only skip "20_dhis2-initwar.sh" on stacks with a single Tomcat node
       PGPASSWORD_FILE: /pass_pg_postgres/pass_pg_postgres.txt
-      WAIT_BEFORE: 10  # Allow time for postgres to initialize itself. Also, 10_dhis2-database.sh will set WAIT_HOSTS to the database host if not specified.
+      WAIT_HOSTS: "database:5432"  # Matches the name and port of the Compose service running PostgreSQL
     command:
       - dhis2-init.sh  # Override the image default
-
-  #
-  # NOTE: This Compose file cannot run multiple Tomcat nodes without additional configuration and a Redis service.
-  #
 
   dhis2:
     image: "ghcr.io/baosystems/dhis2:${DHIS2_TAG:-latest}"
@@ -123,10 +119,10 @@ services:
         target: /pass_pg_dhis
         read_only: true
     environment:
-      DHIS2_DATABASE_HOST: database
+      DHIS2_DATABASE_HOST: database  # Matches the name of the Compose service running PostgreSQL
       DHIS2_DATABASE_PASSWORD_FILE: /pass_pg_dhis/pass_pg_dhis.txt
+      WAIT_HOSTS: "database:5432"  # Matches the name and port of the Compose service running PostgreSQL
       WAIT_PATHS: /dhis2-init.progress/dhis2-init_status.txt  # Allow for dhis2_init to complete (necessary in some cases where dhis2_init may not run again)
-      WAIT_TIMEOUT: 300  # Allow for dhis2_init to complete (default is 30)
     healthcheck:  # NOTE: Compose will not re-create containers marked as unhealthy unless they exit.
       test: ["CMD", "curl", "-fsS", "http://localhost:8080/dhis-web-commons/security/login.action"]
       interval: 1m30s

--- a/helpers/db-empty.sh
+++ b/helpers/db-empty.sh
@@ -41,23 +41,33 @@ if [[ -z "${PGUSER:-}" ]]; then
   export PGUSER='postgres'
 fi
 
-# If WAIT_HOSTS is empty or null, set to PGHOST:PGPORT
-if [[ -z "${WAIT_HOSTS:-}" ]]; then
-  export WAIT_HOSTS="${PGHOST}:${PGPORT}"
-fi
-
-# Disable wait delay as this script is designed to be run interactively
-export WAIT_BEFORE='0'
-
 
 ################################################################################
 
 
-# Wait for hosts specified in the environment variable WAIT_HOSTS (noop if not set).
-# If it times out before the targets are available, it will exit with a non-0 code,
-# and this script will quit because of the bash option "set -e" above.
-# https://github.com/ufoscout/docker-compose-wait
-/usr/local/bin/wait 2> >( sed -r -e 's/^\[(DEBUG|INFO)\s+(wait)\]/[\1] \2:/g' >&2 )
+# Proceed only if wait is available
+if [[ -x /usr/local/bin/wait ]]; then
+
+  # Ensure there are no trailing commas for WAIT_HOSTS or WAIT_PATHS if provided
+  if [[ -n "${WAIT_HOSTS:-}" ]]; then
+    export WAIT_HOSTS="${WAIT_HOSTS%,}"
+  fi
+  if [[ -n "${WAIT_PATHS:-}" ]]; then
+    export WAIT_PATHS="${WAIT_PATHS%,}"
+  fi
+
+  if [[ -n "${WAIT_HOSTS:-}" ]] || [[ -n "${WAIT_PATHS:-}" ]]; then
+    # Disable wait delay as this script is designed to be run interactively
+    export WAIT_BEFORE='0'
+
+    # Wait for hosts specified in the environment variable WAIT_HOSTS (noop if not set).
+    # If it times out before the targets are available, it will exit with a non-0 code,
+    # and this script will quit because of the bash option "set -e" above.
+    # https://github.com/ufoscout/docker-compose-wait
+    /usr/local/bin/wait 2> >( sed -r -e 's/^\[(DEBUG|INFO)\s+(wait)\]/[\1] \2:/g' >&2 )
+  fi
+
+fi
 
 
 ################################################################################
@@ -95,7 +105,7 @@ psql \
   -v ON_ERROR_STOP=1 \
   --command="CREATE EXTENSION IF NOT EXISTS postgis;"
 
-if [[ -e '/dhis2-init.progress/10_dhis2-database_status.txt' ]]; then
+if [[ -f '/dhis2-init.progress/10_dhis2-database_status.txt' ]]; then
   echo "[INFO] $SELF: Delete the '10_dhis2-database_status.txt' progress file so that the database gets re-initialized:"
   rm --verbose --force '/dhis2-init.progress/10_dhis2-database_status.txt'
 fi

--- a/helpers/db-export.sh
+++ b/helpers/db-export.sh
@@ -41,23 +41,33 @@ if [[ -z "${PGUSER:-}" ]]; then
   export PGUSER='postgres'
 fi
 
-# If WAIT_HOSTS is empty or null, set to PGHOST:PGPORT
-if [[ -z "${WAIT_HOSTS:-}" ]]; then
-  export WAIT_HOSTS="${PGHOST}:${PGPORT}"
-fi
-
-# Disable wait delay as this script is designed to be run interactively
-export WAIT_BEFORE='0'
-
 
 ################################################################################
 
 
-# Wait for hosts specified in the environment variable WAIT_HOSTS (noop if not set).
-# If it times out before the targets are available, it will exit with a non-0 code,
-# and this script will quit because of the bash option "set -e" above.
-# https://github.com/ufoscout/docker-compose-wait
-/usr/local/bin/wait 2>/dev/null  # No output to stderr due to strange docker compose run output line break issue
+# Proceed only if wait is available
+if [[ -x /usr/local/bin/wait ]]; then
+
+  # Ensure there are no trailing commas for WAIT_HOSTS or WAIT_PATHS if provided
+  if [[ -n "${WAIT_HOSTS:-}" ]]; then
+    export WAIT_HOSTS="${WAIT_HOSTS%,}"
+  fi
+  if [[ -n "${WAIT_PATHS:-}" ]]; then
+    export WAIT_PATHS="${WAIT_PATHS%,}"
+  fi
+
+  if [[ -n "${WAIT_HOSTS:-}" ]] || [[ -n "${WAIT_PATHS:-}" ]]; then
+    # Disable wait delay as this script is designed to be run interactively
+    export WAIT_BEFORE='0'
+
+    # Wait for hosts specified in the environment variable WAIT_HOSTS (noop if not set).
+    # If it times out before the targets are available, it will exit with a non-0 code,
+    # and this script will quit because of the bash option "set -e" above.
+    # https://github.com/ufoscout/docker-compose-wait
+    /usr/local/bin/wait 2>/dev/null  # No output to stderr due to strange docker compose run output line break issue
+  fi
+
+fi
 
 
 ################################################################################


### PR DESCRIPTION
Switch usage of [wait](https://github.com/ufoscout/docker-compose-wait) to be explicit as there are orchestration scenarios (k8s) that can use other processes to wait for dependent services.

Also, to make the various dhis2-init.sh scripts more portable:
* Move setting default values for environment variables to dhis2-init.sh itself instead of each script
* Don't assume /dhis2-init.progress/ exists to allow for proper usage without it