### PR TITLE
Multiple...

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,6 +171,16 @@ jobs:
           DHIS2_MAJOR="$( cut -c1-4 <<< "${{ steps.get_war.outputs.build_version }}" )"
           echo "::set-output name=dhis2_major::$DHIS2_MAJOR"
 
+          # Trims full version with a _hotfix_ value like "2.36.10.1" or "2.36.10.1-SNAPSHOT", to a _maintenance_ value like "2.36.10"
+          # See https://dhis2-a3b1.kxcdn.com/uploads/default/original/3X/c/d/cd18b97ca7420000bd3c274c470cad01c63e24e5.jpeg
+          # or https://community.dhis2.org/t/hotfix-versioning-convention/47088 for details
+          if grep --quiet --only-matching --extended-regexp '^2\.[0-9]{2}\.[0-9]+\.[0-9]+.*' <<< "${{ matrix.dhis2_version }}" ; then
+            DHIS2_VERSION_MAINT="$( grep --only-matching --extended-regexp '^2\.[0-9]{2}\.[0-9]+' <<< "${{ matrix.dhis2_version }}" )"
+          else
+            DHIS2_VERSION_MAINT="${{ matrix.dhis2_version }}"
+          fi
+          echo "::set-output name=dhis2_version_maint::$DHIS2_VERSION_MAINT"
+
           # Due to limited GHA cache space, only retain Docker cache for one version
           if ${{ matrix.latest_overall }}; then
             echo "::set-output name=cache_to::type=gha,mode=max"
@@ -329,7 +339,7 @@ jobs:
           if [[ "${{ matrix.dhis2_version }}" =~ ^2\.[0-9]{2}-dev$ ]]; then
             DHIS2_DB_URL="https://databases.dhis2.org/sierra-leone/${{ steps.versions_helper.outputs.dhis2_major }}/dhis2-db-sierra-leone.sql.gz"
           else
-            DHIS2_DB_URL="https://databases.dhis2.org/sierra-leone/${{ matrix.dhis2_version }}/dhis2-db-sierra-leone.sql.gz"
+            DHIS2_DB_URL="https://databases.dhis2.org/sierra-leone/${{ steps.versions_helper.outputs.dhis2_version_maint }}/dhis2-db-sierra-leone.sql.gz"
           fi
 
           wget \

--- a/README.md
+++ b/README.md
@@ -258,6 +258,10 @@ for valid values in _dhis.conf_. _Unless otherwise mentioned, no default value i
 
 * `DHIS2_ANALYTICS_CACHE_EXPIRATION`: Value of _analytics.cache.expiration_.
 
+### 2.35.2  and up
+
+* `DHIS2_SYSTEM_PROGRAM_RULE_SERVER_EXECUTION`: Value of _system.program_rule.server_execution_.
+
 ### 2.36 and up
 
 * `DHIS2_SYSTEM_AUDIT_ENABLED`: Value of _system.audit.enabled_.

--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ for valid values in _dhis.conf_. _Unless otherwise mentioned, no default value i
 
 * `DHIS2_SYSTEM_SESSION_TIMEOUT`: Value of _system.session.timeout_.
 
+* `DHIS2_SYSTEM_SQL_VIEW_TABLE_PROTECTION`: Value of _system.sql_view_table_protection_.
+
 * `DHIS2_CHANGELOG_AGGREGATE`: Value of _changelog.aggregate_.
 
 * `DHIS2_CHANGELOG_TRACKER`: Value of _changelog.tracker_.

--- a/remco/templates/dhis2/dhis.conf.tmpl
+++ b/remco/templates/dhis2/dhis.conf.tmpl
@@ -704,6 +704,18 @@ system.cache.cap.percentage = {{ getv("/dhis2/system/cache/cap/percentage") }}
 
 
 # ----------------------------------------------------------------------
+# Advanced
+# ----------------------------------------------------------------------
+
+# SQL view table protection; default is 'on'
+{% if exists("/dhis2/system/sql/view/table/protection") %}
+system.sql_view_table_protection = {{ getv("/dhis2/system/sql/view/table/protection") }}
+{% else %}
+#system.sql_view_table_protection = on
+{% endif %}
+
+
+# ----------------------------------------------------------------------
 # End of template
 # ----------------------------------------------------------------------
 

--- a/remco/templates/dhis2/dhis.conf.tmpl
+++ b/remco/templates/dhis2/dhis.conf.tmpl
@@ -674,6 +674,15 @@ analytics.cache.expiration = {{ getv("/dhis2/analytics/cache/expiration") }}
 {% else %}
 #analytics.cache.expiration = 0
 {% endif %}
+{% if getv("/dhis2/build/version", "") != "2.35.0" and getv("/dhis2/build/version", "") != "2.35.1" %}
+{# The system.program_rule.server_execution option was added in 2.35.2 #}
+# Disable server-side program rule execution; default is 'on'
+{% if exists("/dhis2/system/program/rule/server/execution") %}
+system.program_rule.server_execution = {{ getv("/dhis2/system/program/rule/server/execution") }}
+{% else %}
+#system.program_rule.server_execution = on
+{% endif %}
+{% endif %}
 {% if getv("/dhis2/build/major", "")|cut:"." >= "236" %}
 {# The system.cache.max_size.factor option was added in 2.36 #}
 # Set the maximum size for the cache instance to be built. If set to 0, no caching will take place; default is '0.5'


### PR DESCRIPTION
- Manually create crates.io index for "wait-builder"; was getting killed in GitHub Actions whenever `cargo` ran.
- Trim the hotfix portion of a DHIS2 version for obtaining the correct sample database; "2.36.10.1" becomes "2.36.10" because there is no "2.36.10.1" sample database as of this writing.
- Add support for `system.program_rule.server_execution` in _dhis.conf_.
- Add support for `system.sql_view_table_protection` in _dhis.conf._