### PR TITLE
Support for new major version scheme

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,7 +175,11 @@ jobs:
         run: |
           set -x
           # Trims full version like "2.36.1" or "2.36-dev" to "2.36" from job matrix
-          DHIS2_MAJOR="$( cut -c1-4 <<< "${{ matrix.dhis2_version }}" )"
+          if grep --quiet --extended-regexp '^[0-9]{2}(\.|-)' <<< "${{ matrix.dhis2_version }}" ; then
+            DHIS2_MAJOR="$( cut -c1-2 <<< "${{ matrix.dhis2_version }}" )"
+          else
+            DHIS2_MAJOR="$( cut -c1-4 <<< "${{ matrix.dhis2_version }}" )"
+          fi
 
           if [[ "$DHIS2_MAJOR" == "dev" ]] \
           && [[ "${{ matrix.dhis2_version }}" == "dev" ]]; then
@@ -183,9 +187,9 @@ jobs:
           elif [[ "${{ matrix.dhis2_version }}" =~ ^2\.[0-9]{2}-dev$ ]]; then
             DHIS2_WAR_URL="https://releases.dhis2.org/$DHIS2_MAJOR/dev/dhis2-dev-${DHIS2_MAJOR}.war"
           elif [[ "${{ matrix.dhis2_version }}" == "2.36.0" ]] || [[ "${{ matrix.dhis2_version }}" == "2.36.11" ]]; then
-            DHIS2_WAR_URL="https://dhis2-builds.s3.amazonaws.com/${{ matrix.dhis2_version }}/latest/dhis.war"
+            DHIS2_WAR_URL="https://s3.amazonaws.com/dhis2-builds/${{ matrix.dhis2_version }}/latest/dhis.war"
           else
-            DHIS2_WAR_URL="https://releases.dhis2.org/$DHIS2_MAJOR/dhis2-stable-${{ matrix.dhis2_version }}.war"
+            DHIS2_WAR_URL="$( curl -s https://releases.dhis2.org/v1/versions/stable.json | jq -r '.versions[] | .patchVersions[] | select(.name=="${{ matrix.dhis2_version }}") | .url' )"
           fi
 
           wget \
@@ -195,7 +199,7 @@ jobs:
 
           # Expand to get the contents of build.properties
           unzip -qq source/dhis.war -d source/dhis
-          DHIS2_BUILD_PROPERTIES="$( find source/dhis/WEB-INF/lib/ -name 'dhis-service-core-2.*.jar' -exec unzip -p '{}' build.properties \; )"
+          DHIS2_BUILD_PROPERTIES="$( find source/dhis/WEB-INF/lib/ -name 'dhis-service-core-[0-9]*.jar' -exec unzip -p '{}' build.properties \; )"
           echo "build_version=$( awk -F'=' '/^build\.version/ {gsub(/ /, "", $NF); print $NF}' <<< "$DHIS2_BUILD_PROPERTIES" )" >> $GITHUB_OUTPUT
           echo "build_revision=$( awk -F'=' '/^build\.revision/ {gsub(/ /, "", $NF); print $NF}' <<< "$DHIS2_BUILD_PROPERTIES" )" >> $GITHUB_OUTPUT
           echo "build_time=$( awk -F'=' '/^build\.time/ {sub(/ /, "", $NF); print $NF}' <<< "$DHIS2_BUILD_PROPERTIES" )" >> $GITHUB_OUTPUT
@@ -206,8 +210,27 @@ jobs:
         run: |
           set -x
           # Trims full version like "2.36.1" or "2.36.7-SNAPSHOT" to "2.36" from war file build properties
-          DHIS2_MAJOR="$( cut -c1-4 <<< "${{ steps.get_war.outputs.build_version }}" )"
+          if grep --quiet --extended-regexp '^[0-9]{2}(\.|-)' <<< "${{ steps.get_war.outputs.build_version  }}" ; then
+            DHIS2_MAJOR="$( cut -c1-2 <<< "${{ steps.get_war.outputs.build_version  }}" )"
+          else
+            DHIS2_MAJOR="$( cut -c1-4 <<< "${{ steps.get_war.outputs.build_version  }}" )"
+          fi
           echo "dhis2_major=$DHIS2_MAJOR" >> $GITHUB_OUTPUT
+
+          # 2.40 is co-branded as version 40. Generate alternate image tag values for all 2.40 releases
+          # Other versions will return the same values; duplicate tags will be normalized in steps.image_meta
+          if [[ "${{ matrix.dhis2_version }}" == '2.40-dev' ]] ; then
+            DHIS2_MAJOR_ALT='40'
+            DHIS2_VERSION_ALT='40-dev'
+          elif [[ "$DHIS2_MAJOR" == '2.40' ]] ; then
+            DHIS2_MAJOR_ALT='40'
+            DHIS2_VERSION_ALT="$( curl -s https://releases.dhis2.org/v1/versions/stable.json | jq -r '.versions[] | .patchVersions[] | select(.name=="${{ matrix.dhis2_version }}") | .url' | sed -e 's,^.*/dhis2-stable-,,' -e 's/\.war$//' )"
+          else
+            DHIS2_MAJOR_ALT="$DHIS2_MAJOR"
+            DHIS2_VERSION_ALT='${{ matrix.dhis2_version }}'
+          fi
+          echo "dhis2_major_alt=$DHIS2_MAJOR_ALT" >> $GITHUB_OUTPUT
+          echo "dhis2_version_alt=$DHIS2_VERSION_ALT" >> $GITHUB_OUTPUT
 
           # Trims full version with a _hotfix_ value like "2.36.10.1" or "2.36.10.1-SNAPSHOT", to a _maintenance_ value like "2.36.10"
           # See https://dhis2-a3b1.kxcdn.com/uploads/default/original/3X/c/d/cd18b97ca7420000bd3c274c470cad01c63e24e5.jpeg
@@ -283,6 +306,13 @@ jobs:
             type=raw,value=${{ matrix.dhis2_version }}-tomcat${{ needs[format('baseimage_{0}_query', matrix.java_major)]['outputs']['tomcat_major'] }},enable=${{ !endsWith(matrix.dhis2_version, 'dev') }}
             type=raw,value=${{ matrix.dhis2_version }}-tomcat${{ needs[format('baseimage_{0}_query', matrix.java_major)]['outputs']['tomcat_major'] }}-jre${{ matrix.java_major }},enable=${{ !endsWith(matrix.dhis2_version, 'dev') }}
             type=raw,value=${{ matrix.dhis2_version }}-tomcat${{ needs[format('baseimage_{0}_query', matrix.java_major)]['outputs']['tomcat_version'] }}-jre${{ matrix.java_major }}-temurin-jammy,enable=${{ !endsWith(matrix.dhis2_version, 'dev') }}
+
+            type=raw,value=${{ steps.versions_helper.outputs.dhis2_major_alt }},enable=${{ matrix.latest_major }}
+            type=raw,value=${{ steps.versions_helper.outputs.dhis2_version_alt }}
+            type=raw,value=${{ steps.versions_helper.outputs.dhis2_version_alt }}-jre${{ matrix.java_major }},enable=${{ !endsWith(steps.versions_helper.outputs.dhis2_version_alt, 'dev') }}
+            type=raw,value=${{ steps.versions_helper.outputs.dhis2_version_alt }}-tomcat${{ needs[format('baseimage_{0}_query', matrix.java_major)]['outputs']['tomcat_major'] }},enable=${{ !endsWith(steps.versions_helper.outputs.dhis2_version_alt, 'dev') }}
+            type=raw,value=${{ steps.versions_helper.outputs.dhis2_version_alt }}-tomcat${{ needs[format('baseimage_{0}_query', matrix.java_major)]['outputs']['tomcat_major'] }}-jre${{ matrix.java_major }},enable=${{ !endsWith(steps.versions_helper.outputs.dhis2_version_alt, 'dev') }}
+            type=raw,value=${{ steps.versions_helper.outputs.dhis2_version_alt }}-tomcat${{ needs[format('baseimage_{0}_query', matrix.java_major)]['outputs']['tomcat_version'] }}-jre${{ matrix.java_major }}-temurin-jammy,enable=${{ !endsWith(steps.versions_helper.outputs.dhis2_version_alt, 'dev') }}
 
       - name: Set up QEMU for amd64 and arm64
         uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18

--- a/Dockerfile
+++ b/Dockerfile
@@ -173,7 +173,7 @@ set -euxo pipefail
 # Extract the contents of dhis.war to webapps/ROOT/
 unzip -qq dhis.war -d /usr/local/tomcat/webapps/ROOT
 # Extract build.properties to /
-find /usr/local/tomcat/webapps/ROOT/WEB-INF/lib/ -name 'dhis-service-core-2.*.jar' -exec unzip -p '{}' build.properties \; | tee /build.properties
+find /usr/local/tomcat/webapps/ROOT/WEB-INF/lib/ -name 'dhis-service-core-[0-9]*.jar' -exec unzip -p '{}' build.properties \; | tee /build.properties
 # Remove vulnerable JndiLookup.class to mitigate Log4Shell
 for JAR in /usr/local/tomcat/webapps/ROOT/WEB-INF/lib/log4j-core-2.*.jar ; do
   JAR_LOG4J_VERSION="$( unzip -p "$JAR" 'META-INF/maven/org.apache.logging.log4j/log4j-core/pom.properties' | awk -F'=' '/^version=/ {print $NF}' )"

--- a/dhis2-init.d/20_dhis2-initwar.sh
+++ b/dhis2-init.d/20_dhis2-initwar.sh
@@ -79,7 +79,7 @@ if [[ -d /dhis2-init.progress/ ]]; then
   fi
 
   # Set DHIS2 build information (logic also used in docker-entrypoint.sh)
-  DHIS2_BUILD_PROPERTIES="$( unzip -q -p "$( find /usr/local/tomcat/webapps/ROOT/WEB-INF/lib -maxdepth 1 -type f -name "dhis-service-core-2.*.jar" )" build.properties )"
+  DHIS2_BUILD_PROPERTIES="$( unzip -q -p "$( find /usr/local/tomcat/webapps/ROOT/WEB-INF/lib -maxdepth 1 -type f -name 'dhis-service-core-[0-9]*.jar' )" build.properties )"
   DHIS2_BUILD_VERSION="$( awk -F'=' '/^build\.version/ {gsub(/ /, "", $NF); print $NF}' <<< "$DHIS2_BUILD_PROPERTIES" )"
   DHIS2_BUILD_REVISION="$( awk -F'=' '/^build\.revision/ {gsub(/ /, "", $NF); print $NF}' <<< "$DHIS2_BUILD_PROPERTIES" )"
   DHIS2_BUILD_TIME="$( awk -F'=' '/^build\.time/ {sub(/ /, "", $NF); print $NF}' <<< "$DHIS2_BUILD_PROPERTIES" )"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -30,7 +30,7 @@ _main() {
 
     # Set DHIS2 build information (logic also used in 20_dhis2-initwar.sh):
 
-    DHIS2_BUILD_PROPERTIES="$( unzip -q -p "$( find /usr/local/tomcat/webapps/ROOT/WEB-INF/lib -maxdepth 1 -type f -name "dhis-service-core-2.*.jar" )" build.properties )"
+    DHIS2_BUILD_PROPERTIES="$( unzip -q -p "$( find /usr/local/tomcat/webapps/ROOT/WEB-INF/lib -maxdepth 1 -type f -name 'dhis-service-core-[0-9]*.jar' )" build.properties )"
     export DHIS2_BUILD_VERSION="$( awk -F'=' '/^build\.version/ {gsub(/ /, "", $NF); print $NF}' <<< "$DHIS2_BUILD_PROPERTIES" )"
     export DHIS2_BUILD_MAJOR="$( cut -c1-4 <<< "$DHIS2_BUILD_VERSION" )"
     export DHIS2_BUILD_REVISION="$( awk -F'=' '/^build\.revision/ {gsub(/ /, "", $NF); print $NF}' <<< "$DHIS2_BUILD_PROPERTIES" )"


### PR DESCRIPTION
* The current version of DHIS2 is 2.40, but is also being co-branded as 40. Support tags for both.
* The next version of DHIS2 is 41. Prepare logic and regex for the upcoming version pattern.
* Get artifact URLs for stable releases from https://releases.dhis2.org/v1/versions/stable.json