### PR TITLE
ci: switch to GitHub CLI command

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -212,11 +212,9 @@ jobs:
 
       - name: Enable Pull Request Automerge
         if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@684fed02ccc9b5eefcf7d40b65b3cd44255bd5bc
-        with:
-          token: ${{ secrets.PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-          merge-method: rebase
+        run: gh pr merge --rebase --auto "${{ steps.cpr.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
 
       - name: Auto-approve Pull Request
         if: steps.cpr.outputs.pull-request-operation == 'created'


### PR DESCRIPTION
The upgrade notes from peter-evans/enable-pull-request-automerge from 2.5.0 to 3.0.0 state that it is now recommended to use the gh cli tool instead of the Action.

Closes #203