### PR TITLE
fix: change method for upgrading postgis

### DIFF
--- a/dhis2-init.d/10_dhis2-database.sh
+++ b/dhis2-init.d/10_dhis2-database.sh
@@ -151,8 +151,7 @@ EOSQL
 
   psql --dbname "$DHIS2_DATABASE_NAME" --echo-all --echo-hidden -v ON_ERROR_STOP=1 <<- EOSQL
 -- Update PostGIS to the latest version available
-ALTER EXTENSION postgis UPDATE TO '${POSTGIS_VERSION}next';
-ALTER EXTENSION postgis UPDATE TO '${POSTGIS_VERSION}';
+SELECT postgis_extensions_upgrade();
 EOSQL
 fi
 


### PR DESCRIPTION
PostGIS 3.4 no longer supports the "next" update pattern.